### PR TITLE
[장재원] Add : MyBoardView for create board in mypage

### DIFF
--- a/boards/urls.py
+++ b/boards/urls.py
@@ -1,9 +1,8 @@
 from django.urls import path
-
-from .views      import BoardListView,PinListView
-
+from .views      import BoardListView, MyBoardsView, PinListView
 
 urlpatterns = [
     path("", BoardListView.as_view()),
     path("/pinlist", PinListView.as_view()),
+    path("/board/me", MyBoardsView.as_view()),
 ]

--- a/boards/views.py
+++ b/boards/views.py
@@ -105,7 +105,7 @@ class PinListView(View):
     def get(self, request):
         OFFSET  = int(request.GET.get("offset", 0))
         LIMIT   = int(request.GET.get("limit", 25))
-        
+
         user   = request.user
         boards = user.pined_boards.all()[OFFSET:OFFSET+LIMIT]
 
@@ -126,3 +126,28 @@ class PinListView(View):
 
         return JsonResponse({"pined_boards" : results}, status=200)
 
+
+class MyBoardsView(View):
+    @login_decorator
+    def get(self, request):
+        user   = request.user
+
+        if not user.board_set.all().exists():
+            return JsonResponse({"message": "DOSE_NOT_EXIST_CREATE_BOARD"}, status=404)
+
+        boards = user.board_set.all().order_by("create_time")
+
+        result = [
+            {
+                "id"           : board.id,
+                "user"         : user.nickname,
+                "title"        : board.title,
+                "image_url"    : board.board_image_url,
+                "point_color"  : board.image_point_color,
+                "image_width"  : board.image_width,
+                "image_height" : board.image_height,
+            }
+            for board in boards
+        ]
+
+        return JsonResponse({"message": result}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 자신이 생성한 board list를 마이페이지에 제공하는 API 입니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인한 유저가 생성한 board를 list로 제공합니다.
- exists로 존재하는지 확인 후, 존재하지 않으면 DOES_NOT_EXIST_CREATE_BOARD를 응답합니다.
- 존재하다면, 최신순으로 list를 제공합니다.

2. test.py 및 postman을 통해 test하였습니다.
- postman 테스트 결과 
<img width="2130" alt="스크린샷 2021-11-23 오후 8 54 58" src="https://user-images.githubusercontent.com/67135804/143021004-2c7f1861-5f36-432c-935a-0c385fda135c.png">
- unit test(test.py) 결과
<img width="1268" alt="스크린샷 2021-11-23 오후 8 54 29" src="https://user-images.githubusercontent.com/67135804/143020649-fa59ae6e-0983-4b89-bdec-c4b7d49f820b.png">

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 생성하는 post 매서드와 생성한 결과를 get하는 메서드가 같은 클래스에 있어야하는 줄 알았는데, 분리시키는게 현재 더 자연스럽게 느낍니다.
- 따라서 API를 구성할 때, 어떤 체계로 클래스에 나눠야하는지 익혔습니다.

<br />

## :: 기타 질문 및 특이 사항
- 추후 API 기능 구현 사항 : BoardDetailView 예정
