### PR TITLE
Add: BoardDetailView for detail page

### DIFF
--- a/boards/urls.py
+++ b/boards/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views      import BoardListView, MyBoardsView, PinListView
+from .views      import BoardListView, MyBoardsView, PinListView, BoardDetailView
 
 urlpatterns = [
     path("", BoardListView.as_view()),
     path("/pin", PinListView.as_view()),
     path("/board/me", MyBoardsView.as_view()),
+    path("/<int:board_id>", BoardDetailView.as_view()),
 ]


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Detail Page 정보를 응답하는 BoardDetailView API 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Board의 기본 정보 제공 및 댓글 정보 제공
- Board의 기본정보인 id, title, descritpion, board_image_url, source, username, tag_id를 전달합니다.
- tag_id를 전달하는 이유는 상세페이지 아랫단에 나타나는 유사 BoardListView에서 query로 tag정보를 받아야하기 때문입니다.

2. PostMan 및 Unit Test 완료
- PostMan 결과 
<img width="1355" alt="스크린샷 2021-11-24 오전 10 53 57" src="https://user-images.githubusercontent.com/67135804/143157894-f6e16c2a-77c0-4281-87e5-62e11180cc41.png">

- Unit Test 결과
<img width="1270" alt="스크린샷 2021-11-24 오전 10 53 26" src="https://user-images.githubusercontent.com/67135804/143157911-f76bd73a-eb8f-4759-8dd7-c141eec519a0.png">

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Test 과정에서 DiffMax 에러가 발생해서 maxDiff=None을 사용했습니다.

<br />

## :: 기타 질문 및 특이 사항
- Docker로 배포를 꼭 하고싶습니다!!!!! 아자!
